### PR TITLE
chore: bump deco-cx/apps to 0.147.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.103.0/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.151.1/",
     "$fresh/": "https://deno.land/x/fresh@1.7.3/",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.5",
     "@core/asyncutil": "jsr:@core/asyncutil@^1.0.0",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
     "deco/": "https://cdn.jsdelivr.net/gh/deco-cx/deco@1.103.0/",
-    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.118.0/",
+    "apps/": "https://cdn.jsdelivr.net/gh/deco-cx/apps@0.147.0/",
     "$fresh/": "https://deno.land/x/fresh@1.7.3/",
     "@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.5",
     "@core/asyncutil": "jsr:@core/asyncutil@^1.0.0",


### PR DESCRIPTION
Bumps `deco-cx/apps` to [`0.147.0`](https://github.com/deco-cx/apps/releases/tag/0.147.0).

**Release highlight:** _Migrate asset URLs to `decoims.com` (clean cutover, drop `ENABLE_AZION_ASSETS`)._

Opened as a **draft** so CI runs but the PR doesn't auto-merge. If your site uses shared image hosts (assets.decocache.com, deco-assets.edgedeco.com, etc.), this bump migrates those asset URLs to `decoims.com`. Verify image rendering on a preview deployment before marking ready-for-review.

Generated by `scripts/bump-apps-0.147.0/bump.py` (stats-lake repo).